### PR TITLE
Remove official support from Heltec Mesh Node 114

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -405,7 +405,7 @@ export const deviceHardwareList: DeviceHardware[] = [
     hwModelSlug: "HELTEC_MESH_NODE_T114",
     platformioTarget: "heltec-mesh-node-t114",
     architecture: "nrf52840",
-    activelySupported: true,
+    activelySupported: false,
     displayName: "Heltec Mesh Node T114",
   },
   {


### PR DESCRIPTION
This node has a hardware flaw that prevents it being used at full power or with long fast reliably.