### PR TITLE
Add seeed xiao s3

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -424,4 +424,12 @@ export const deviceHardwareList: DeviceHardware[] = [
     activelySupported: true,
     displayName: "Seeed Card Tracker T1000-E",
   },
+  {
+    hwModel: 72,
+    hwModelSlug: "Seeed_XIAO_S3",
+    platformioTarget: "seeed-xiao-s3",
+    architecture: "esp32-s3",
+    activelySupported: true,
+    displayName: "Seeed XIAO S3",
+  },
 ];


### PR DESCRIPTION
# Describe
The SEEED Xiao S3 development board and its accompanying extension board have fully supported  in Meshtastic FW. 
Please merge PR for compatibility on web flasher