### PR TITLE
fix: `hwModel` and `hwModelSlug` for Seeed Xiao ESP32-S3

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -584,8 +584,8 @@ export const deviceHardwareList: DeviceHardware[] = [
     requiresDfu: true,
   },
   {
-    hwModel: 72,
-    hwModelSlug: "Seeed_XIAO_S3",
+    hwModel: 81,
+    hwModelSlug: "SEEED_XIAO_S3",
     platformioTarget: "seeed-xiao-s3",
     architecture: "esp32-s3",
     activelySupported: true,


### PR DESCRIPTION
https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L641

```
 /* Seeed XIAO S3 DK*/
  SEEED_XIAO_S3 = 81;
```