### PR TITLE
Add ThinkNode M1/M2

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -694,6 +694,6 @@ export const deviceHardwareList: DeviceHardware[] = [
     supportLevel: 1,
     displayName: "ThinkNode M2",
     tags: ["Elecrow"],
-    requiresDfu: true,
+    requiresDfu: false,
   } 
 ];

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -673,5 +673,27 @@ export const deviceHardwareList: DeviceHardware[] = [
     tags: ["Seeed"],
     requiresDfu: true,
     images: ["seeed_xiao_nrf52_kit.svg"]
-  }
+  },
+  { 
+    hwModel: 89,
+    hwModelSlug: "THINKNODE_M1",
+    platformioTarget: "thinknode_m1",
+    architecture: "nrf52840",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "ThinkNode M1",
+    tags: ["Elecrow"],
+    requiresDfu: true,
+  },
+  {
+    hwModel: 90,
+    hwModelSlug: "THINKNODE_M2",
+    platformioTarget: "thinknode_m2",
+    architecture: "esp32-s3",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "ThinkNode M2",
+    tags: ["Elecrow"],
+    requiresDfu: true,
+  } 
 ];


### PR DESCRIPTION
Adds M1/M2 to API. Have `activelySupported: false` for now since support hasn't been merged into firmware yet. Also, for ThinkNode M1 for pro target I'm making an assumption as there's no PR for that yet. 
