### PR TITLE
Add LilyGo T-Lora C6 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1168,5 +1168,6 @@ export const deviceHardwareList: DeviceHardware[] = [
     supportLevel: 1,
     displayName: "LilyGo T-Lora C6",
     tags: ["LilyGo"],
+    images: ["tlora-c6.svg"]
   },
 ];

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1168,6 +1168,6 @@ export const deviceHardwareList: DeviceHardware[] = [
     supportLevel: 1,
     displayName: "LilyGo T-Lora C6",
     tags: ["LilyGo"],
-    images: ["tlora-c6.svg"]
+    images: ["tlora-c6.svg"],
   },
 ];

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1159,4 +1159,14 @@ export const deviceHardwareList: DeviceHardware[] = [
     requiresDfu: true,
     partitionScheme: "16MB",
   },
+  {
+    hwModel: 83,
+    hwModelSlug: "TLORA_C6",
+    platformioTarget: "tlora-c6",
+    architecture: "esp32-c6",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "LilyGo T-Lora C6",
+    tags: ["LilyGo"],
+  },
 ];


### PR DESCRIPTION
Adds the **LilyGo T-Lora C6** to `deviceHardwareList`, keyed by [`TLORA_C6 = 83`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L651).

```ts
  {
    hwModel: 83,
    hwModelSlug: "TLORA_C6",
    platformioTarget: "tlora-c6",
    architecture: "esp32-c6",
    activelySupported: false,
    supportLevel: 1,
    displayName: "LilyGo T-Lora C6",
    tags: ["LilyGo"],
  },
```

Review checklist:
- [x] `platformioTarget` — **derived from the slug**; confirm against the firmware variant
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [x] add `images` once the device SVG lands
- [x] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._