### PR TITLE
Add Heltec Mesh Node T1 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1170,4 +1170,14 @@ export const deviceHardwareList: DeviceHardware[] = [
     tags: ["LilyGo"],
     images: ["tlora-c6.svg"],
   },
+  {
+    hwModel: 133,
+    hwModelSlug: "HELTEC_MESH_NODE_T1",
+    platformioTarget: "heltec-mesh-node-t1",
+    architecture: "nrf52840",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "Heltec Mesh Node T1",
+    tags: ["Heltec"],
+  },
 ];


### PR DESCRIPTION
Adds the **Heltec Automation Mesh Node T1** to `deviceHardwareList`, keyed by [`HELTEC_MESH_NODE_T1 = 133`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L899).

```ts
  {
    hwModel: 133,
    hwModelSlug: "HELTEC_MESH_NODE_T1",
    platformioTarget: "heltec-mesh-node-t1",
    architecture: "nrf52840",
    activelySupported: false,
    supportLevel: 1,
    displayName: "Heltec Mesh Node T1",
    tags: ["Heltec"],
  },
```

Review checklist:
- [x] `platformioTarget` matches the firmware env (`heltec-mesh-node-t1`)
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [ ] add `images` once the device SVG lands
- [x] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._