### PR TITLE
feat: populate Open Sauce 2026 event firmware

### DIFF
--- a/data/eventFirmware.json
+++ b/data/eventFirmware.json
@@ -50,19 +50,19 @@
         { "label": "Event Website", "url": "https://opensauce.com" }
       ],
       "theme": {
-        "name": null,
-        "tagline": null,
+        "name": "Makers & Mesh",
+        "tagline": "Where makers, science, and mesh collide.",
         "colors": { "primary": "#E94F1D", "secondary": null, "accent": null },
         "palette": ["#E94F1D"],
         "fonts": null
       },
       "firmware": {
         "slug": "opensauce2026",
-        "version": null,
-        "id": null,
-        "title": null,
-        "zipUrl": null,
-        "releaseNotes": null
+        "version": "2.7.26.004b486",
+        "id": "v2.7.26.004b486",
+        "title": "Meshtastic Firmware 2.7.26.004b486",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/opensauce2026/firmware-2.7.26.004b486.zip",
+        "releaseNotes": "## Welcome to Open Sauce 2026! 🔧\n\nThis firmware has been customized for Open Sauce with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the Open Sauce mode.\n\n**Happy meshing from San Mateo!**"
       }
     },
     {


### PR DESCRIPTION
## What

Fills in the **Open Sauce 2026** edition's firmware and branding in `data/eventFirmware.json`. It shipped with null firmware (rendered as "coming soon" in the web-flasher); this makes the edition serve a flashable build.

- `firmware`: `v2.7.26.004b486` (derived from the `event/opensauce2026` branch), event-tailored release notes, and the `meshtastic.github.io/event/opensauce2026/...` zip URL.
- `theme`: name + tagline ("Where makers, science, and mesh collide.").
- `iconUrl` stays null — the web-flasher renders a dedicated Meshtastic × Open Sauce header lockup.

Companion to meshtastic/web-flasher#370 (which mirrors this into the bundled offline snapshot and adds the header mode). This repo is the source of truth, so this PR is what makes the branding/firmware survive the web-flasher's background API refresh.

## ⚠️ Before merge

The firmware hash `004b486` is the `event/opensauce2026` branch HEAD, **not** a published artifact — the zip 404s until CI publishes to `meshtastic.github.io/event/opensauce2026/`. Confirm the real `version`/`zipUrl` before merging so attendees don't hit a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Open Sauce edition with a named theme, refreshed tagline, and fully populated firmware details.
  * Added specific version, title, download link, and release notes information for the edition.
  * Replaced placeholder values with complete metadata for a more polished experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->