### PR TITLE
Add Seeed SenseCap Mesh Tracker X1 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1181,4 +1181,14 @@ export const deviceHardwareList: DeviceHardware[] = [
     displayName: "Heltec Mesh Node T1",
     tags: ["Heltec"],
   },
+  {
+    hwModel: 128,
+    hwModelSlug: "MESH_TRACKER_X1",
+    platformioTarget: "seeed_mesh_tracker_X1",
+    architecture: "nrf52840",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "Seeed SenseCap Mesh Tracker X1",
+    tags: ["Seeed"],
+  },
 ];


### PR DESCRIPTION
Adds the **Seeed Studio Seeed SenseCap Mesh Tracker X1** to `deviceHardwareList`, keyed by [`MESH_TRACKER_X1 = 128`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L882).

```ts
  {
    hwModel: 128,
    hwModelSlug: "MESH_TRACKER_X1",
    platformioTarget: "seeed_mesh_tracker_X1",
    architecture: "nrf52840",
    activelySupported: false,
    supportLevel: 1,
    displayName: "Seeed SenseCap Mesh Tracker X1",
    tags: ["Seeed"],
  },
```

Review checklist:
- [ ] `platformioTarget` matches the firmware env (`seeed_mesh_tracker_X1`)
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [ ] add `images` once the device SVG lands
- [ ] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Seeed SenseCap Mesh Tracker X1 to the available hardware catalog.
  * The device is listed with its model details and compatibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->