### PR TITLE
feat: wire in published FAB26 firmware build

### DIFF
--- a/data/eventFirmware.json
+++ b/data/eventFirmware.json
@@ -89,12 +89,12 @@
         "fonts": { "heading": "Montserrat", "body": "Montserrat" }
       },
       "firmware": {
-        "slug": "fab2026",
-        "version": null,
-        "id": null,
-        "title": null,
-        "zipUrl": null,
-        "releaseNotes": null
+        "slug": "fab26",
+        "version": "2.7.27.d250d89",
+        "id": "v2.7.27.d250d89",
+        "title": "Meshtastic Firmware 2.7.27.d250d89",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/fab26/firmware-2.7.27.d250d89.zip",
+        "releaseNotes": "## Welcome to FAB26 Boston! 🛠️\n\nThis firmware has been customized for FAB26 Boston with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the FAB26 mode.\n\n**Happy meshing from Boston!**"
       }
     },
     {


### PR DESCRIPTION
## Summary

The FAB26 Boston firmware build has been published to [`meshtastic.github.io/event/fab26/firmware-2.7.27.d250d89`](https://github.com/meshtastic/meshtastic.github.io/tree/master/event/fab26). This populates the FAB26 edition's `firmware` block, which was `null` ("coming soon") when the edition was first added.

## Changes

- `firmware.version` → `2.7.27.d250d89`, `id` → `v2.7.27.d250d89`, `title`, `zipUrl`, and event `releaseNotes`.
- **Corrects `firmware.slug`** from the provisional `fab2026` to the published **`fab26`**. The web-flasher derives its download path as `event/{slug}/firmware-{version}`, so the slug must match the real directory.

## Verification

The exact path the flasher builds resolves:
`raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/event/fab26/firmware-2.7.27.d250d89/firmware-2.7.27.d250d89.json` → **200**.

## Companion

- **web-flasher** — a matching PR updates the bundled `event_firmware.json` fallback so offline resolution flashes the shipped build too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FAB26 Boston event with accurate firmware version details, download information, and release notes.
  * Corrected the event firmware identifier and replaced missing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->