### PR TITLE
Add Elecrow ThinkNode M8 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1180,7 +1180,7 @@ export const deviceHardwareList: DeviceHardware[] = [
     supportLevel: 1,
     displayName: "Heltec Mesh Node T1",
     tags: ["Heltec"],
-    images: ["heltec-meshnode-t1.svg"]
+    images: ["heltec-meshnode-t1.svg"],
   },
   {
     hwModel: 128,

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1192,4 +1192,15 @@ export const deviceHardwareList: DeviceHardware[] = [
     displayName: "Seeed MeshTracker X1",
     tags: ["Seeed"],
   },
+  {
+    hwModel: 130,
+    hwModelSlug: "THINKNODE_M8",
+    platformioTarget: "thinknode_m8",
+    architecture: "nrf52840",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "Elecrow ThinkNode M8",
+    tags: ["Elecrow"],
+    images: ["thinknode-m8.svg"],
+  },
 ];


### PR DESCRIPTION
Adds the **Elecrow ThinkNode M8** to `deviceHardwareList`, keyed by [`THINKNODE_M8 = 130`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L888).

```ts
  {
    hwModel: 130,
    hwModelSlug: "THINKNODE_M8",
    platformioTarget: "thinknode_m8",
    architecture: "nrf52840",
    activelySupported: false,
    supportLevel: 1,
    displayName: "Elecrow ThinkNode M8",
    tags: ["Elecrow"],
    images: ["thinknode-m8.svg"],
  },
```

Review checklist:
- [ ] `platformioTarget` matches the firmware env (`thinknode_m8`)
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [ ] confirm `images: ["thinknode-m8.svg"]` is live in meshtastic/web-flasher (merge the device-image PR first)
- [ ] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the THINKNODE M8 hardware device.
  * Included device details such as platform compatibility, architecture, support status, display name, tags, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->