### PR TITLE
feat: wire in published DEF CON 34 firmware build

### DIFF
--- a/data/eventFirmware.json
+++ b/data/eventFirmware.json
@@ -122,12 +122,12 @@
         "fonts": { "heading": "Lato", "body": "Atkinson Hyperlegible" }
       },
       "firmware": {
-        "slug": "defcon2026",
-        "version": null,
-        "id": null,
-        "title": null,
-        "zipUrl": null,
-        "releaseNotes": null
+        "slug": "defcon34",
+        "version": "2.8.0.b00d76f",
+        "id": "v2.8.0.b00d76f",
+        "title": "Meshtastic Firmware 2.8.0.b00d76f",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/defcon34/firmware-2.8.0.b00d76f.zip",
+        "releaseNotes": "> ⚠️ **Preview Build:** This is a preview release for DEF CON 34 and may change before the event.\n\n## Welcome to DEF CON 34! 💀\n\nThis firmware has been customized for DEF CON 34 with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the DEF CON mode.\n\n**Happy meshing from Las Vegas!**"
       }
     },
     {


### PR DESCRIPTION
## Summary
- The DEF CON 34 build has shipped to `meshtastic.github.io/event/defcon34/firmware-2.8.0.b00d76f`, so populate the edition's firmware block (version/id/title/zipUrl/releaseNotes), which was `null` ("coming soon").
- Corrects the firmware slug from the provisional `defcon2026` to the published `defcon34` — the flasher derives `event/{slug}/firmware-{version}` from it, so it must match the real path.
- Release notes now lead with a preview-build warning.

## Test plan
- [x] Validated `data/eventFirmware.json` as well-formed JSON
- [x] Confirmed `event/defcon34/firmware-2.8.0.b00d76f` exists in meshtastic.github.io via the GitHub API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable DEF CON 34 firmware details, including version, title, identifier, and ZIP archive.
  * Added release notes indicating the firmware is a preview build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->