### PR TITLE
feat: update DEF CON 34 firmware to 2.8.0.c800fc8

### DIFF
--- a/data/eventFirmware.json
+++ b/data/eventFirmware.json
@@ -123,10 +123,10 @@
       },
       "firmware": {
         "slug": "defcon34",
-        "version": "2.8.0.8adc7c3",
-        "id": "v2.8.0.8adc7c3",
-        "title": "Meshtastic Firmware 2.8.0.8adc7c3",
-        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/defcon34/firmware-2.8.0.8adc7c3.zip",
+        "version": "2.8.0.c800fc8",
+        "id": "v2.8.0.c800fc8",
+        "title": "Meshtastic Firmware 2.8.0.c800fc8",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/defcon34/firmware-2.8.0.c800fc8.zip",
         "releaseNotes": "## Welcome to DEF CON 34! 💀\n\nThis firmware has been customized for DEF CON 34 with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the DEF CON mode.\n\n**Happy meshing from Las Vegas!**"
       }
     },


### PR DESCRIPTION
Points the DEF CON 34 edition at the next published build:
[`event/defcon34/firmware-2.8.0.c800fc8`](https://github.com/meshtastic/meshtastic.github.io/tree/master/event/defcon34/firmware-2.8.0.c800fc8) (was `2.8.0.b00d76f` → `2.8.0.8adc7c3`).

- `version` / `id` / `title` / `zipUrl` bumped to `2.8.0.c800fc8`
- `slug` stays `defcon34`, so the flasher's derived path `event/{slug}/firmware-{version}` resolves to the new directory
- Release notes unchanged (the preview-build warning was already dropped in the previous bump)

## What's in the new build

Two commits on top of `2.8.0.8adc7c3` on [`event/defcon34`](https://github.com/meshtastic/firmware/tree/event/defcon34):

1. **The custom DEF CON boot logo renders again on MUI hardware.** `8adc7c3` shipped the stock Meshtastic logo on the T-Deck boot screen instead of the event logo. The branding pipeline was fine — the logo is byte-identical in both builds' littlefs images — but firmware meshtastic/firmware#11214 bumped device-ui to a commit that sets `LV_USE_LODEPNG 0` without registering its PNGdec replacement as an LVGL image decoder, leaving LVGL with no decoder for a PNG *file* source. The event branch now holds the device-ui pin at `ef573c3`. Upstream: meshtastic/device-ui#357.
2. **Signing and ingress hardening** — cherry-pick of meshtastic/firmware#11282 (licensed-unicast signature requirement, PKI encryption failures now fail the send, hop clamping on UDP multicast ingress, warm-tier signers in the identity/NodeInfo gates).

## ⛔ Do not merge until the build publishes

The publishing run is in flight: [firmware run 30500538943](https://github.com/meshtastic/firmware/actions/runs/30500538943). Until it finishes, `event/defcon34/firmware-2.8.0.c800fc8/` does not exist and merging this would point the flasher at a 404.

Gate on this returning `200` for both the manifest and a sample artifact:

```bash
for f in firmware-2.8.0.c800fc8.json firmware-heltec-v3-2.8.0.c800fc8.factory.bin; do curl -s -o /dev/null -w "%{http_code} $f\n" "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/event/defcon34/firmware-2.8.0.c800fc8/$f"; done
```

Local verification already done on the firmware side: `t-deck-tft` builds clean at this SHA (flash 58.2% of the 6.5 MB app partition), `lv_lodepng.c.o` is linked in, and the DEF CON logo is present in the produced `littlefs-t-deck-tft-2.8.0.c800fc8.bin`.

Note (pre-existing, not changed here): the `zipUrl` convention — `event/{slug}/firmware-{version}.zip` — 404s for *every* edition, since github.io stores these builds as directories rather than a single zip. Carried forward as-is; worth a separate cleanup if nothing consumes it.


Companion: meshtastic/web-flasher#390 keeps the flasher's bundled fallback copy in sync; this PR updates the live manifest. Merge both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the DEF CON 34 event firmware metadata to reference the latest firmware release.
  * Refreshed the associated firmware version, identifier, title, and download link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->