### PR TITLE
Add LilyGo T-Beam BPF

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1203,4 +1203,15 @@ export const deviceHardwareList: DeviceHardware[] = [
     tags: ["Elecrow"],
     images: ["thinknode-m8.svg"],
   },
+  {
+    hwModel: 124,
+    hwModelSlug: "TBEAM_BPF",
+    platformioTarget: "t-beam-bpf",
+    architecture: "esp32-s3",
+    activelySupported: true,
+    supportLevel: 3,
+    displayName: "LilyGo T-Beam BPF",
+    tags: ["LilyGo"],
+    images: ["tbeam-bpf.svg"],
+  },
 ];


### PR DESCRIPTION
Add T-Beam BPF. "Community Supported" for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LilyGo T-Beam BPF hardware device.
  * Included device details, compatibility information, manufacturer data, and product imagery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->