### PR TITLE
Add Elecrow ThinkNode M9 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1215,4 +1215,14 @@ export const deviceHardwareList: DeviceHardware[] = [
     tags: ["LilyGo"],
     images: ["tbeam-bpf.svg"],
   },
+  {
+    hwModel: 131,
+    hwModelSlug: "THINKNODE_M9",
+    platformioTarget: "thinknode-m9",
+    architecture: "esp32-s3",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "Elecrow ThinkNode M9",
+    tags: ["Elecrow"],
+  },
 ];

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1222,6 +1222,7 @@ export const deviceHardwareList: DeviceHardware[] = [
     architecture: "esp32-s3",
     activelySupported: false,
     supportLevel: 1,
+    partitionScheme: "16MB",
     displayName: "Elecrow ThinkNode M9",
     tags: ["Elecrow"],
   },


### PR DESCRIPTION
Adds the **Elecrow ThinkNode M9** to `deviceHardwareList`, keyed by [`THINKNODE_M9 = 131`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L889).

```ts
  {
    hwModel: 131,
    hwModelSlug: "THINKNODE_M9",
    platformioTarget: "thinknode-m9",
    architecture: "esp32-s3",
    activelySupported: false,
    supportLevel: 1,
    partitionScheme: "16MB",
    displayName: "Elecrow ThinkNode M9",
    tags: ["Elecrow"],
  },
```

Review checklist:
- [x] `platformioTarget` — **derived from the slug**; confirm against the firmware variant
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [ ] add `images` once the device SVG lands
- [x] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._