### PR TITLE
Add a bootloaderOtaQuirks resource endpoint

### DIFF
--- a/data/bootloaderOtaQuirks.json
+++ b/data/bootloaderOtaQuirks.json
@@ -1,0 +1,280 @@
+{
+  "devices": [
+    {
+      "hwModel": 18,
+      "hwModelSlug": "NANO_G2_ULTRA",
+      "requiresBootloaderUpgradeForOta": true,
+      "infoUrl": "https://meshtastic.org/docs/getting-started/flashing-firmware/nrf52/update-nrf52-bootloader/"
+    },
+    {
+      "hwModel": 9,
+      "hwModelSlug": "RAK4631",
+      "requiresBootloaderUpgradeForOta": true,
+      "infoUrl": "https://meshtastic.org/docs/getting-started/flashing-firmware/nrf52/update-nrf52-bootloader/"
+    },
+    {
+      "hwModel": 96,
+      "hwModelSlug": "NOMADSTAR_METEOR_PRO",
+      "requiresBootloaderUpgradeForOta": true,
+      "infoUrl": "https://meshtastic.org/docs/getting-started/flashing-firmware/nrf52/update-nrf52-bootloader/"
+    }
+  ],
+  "softDeviceVariants": [
+    {
+      "hwModel": 7,
+      "hwModelSlug": "T_ECHO",
+      "platformioTargets": [
+        "t-echo"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 9,
+      "hwModelSlug": "RAK4631",
+      "platformioTargets": [
+        "rak4631"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 18,
+      "hwModelSlug": "NANO_G2_ULTRA",
+      "platformioTargets": [
+        "nano-g2-ultra"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 21,
+      "hwModelSlug": "WIO_WM1110",
+      "platformioTargets": [
+        "wio-tracker-wm1110"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 22,
+      "hwModelSlug": "WISMESH_HUB",
+      "platformioTargets": [
+        "rak2560"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 29,
+      "hwModelSlug": "CANARYONE",
+      "platformioTargets": [
+        "canaryone"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 33,
+      "hwModelSlug": "T_ECHO_PLUS",
+      "platformioTargets": [
+        "t-echo-plus"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 63,
+      "hwModelSlug": "NRF52_PROMICRO_DIY",
+      "platformioTargets": [
+        "nrf52_promicro_diy_tcxo"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 69,
+      "hwModelSlug": "HELTEC_MESH_NODE_T114",
+      "platformioTargets": [
+        "heltec-mesh-node-t114"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 71,
+      "hwModelSlug": "TRACKER_T1000_E",
+      "platformioTargets": [
+        "tracker-t1000-e"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 84,
+      "hwModelSlug": "WISMESH_TAP",
+      "platformioTargets": [
+        "rak_wismeshtap"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 88,
+      "hwModelSlug": "XIAO_NRF52_KIT",
+      "platformioTargets": [
+        "seeed_xiao_nrf52840_kit"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 89,
+      "hwModelSlug": "THINKNODE_M1",
+      "platformioTargets": [
+        "thinknode_m1"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 93,
+      "hwModelSlug": "MUZI_BASE",
+      "platformioTargets": [
+        "muzi-base"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 94,
+      "hwModelSlug": "HELTEC_MESH_POCKET",
+      "platformioTargets": [
+        "heltec-mesh-pocket-10000",
+        "heltec-mesh-pocket-5000"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 95,
+      "hwModelSlug": "SEEED_SOLAR_NODE",
+      "platformioTargets": [
+        "seeed_solar_node"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 96,
+      "hwModelSlug": "NOMADSTAR_METEOR_PRO",
+      "platformioTargets": [
+        "rak4631_nomadstar_meteor_pro"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 99,
+      "hwModelSlug": "SEEED_WIO_TRACKER_L1",
+      "platformioTargets": [
+        "seeed_wio_tracker_L1"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 100,
+      "hwModelSlug": "SEEED_WIO_TRACKER_L1_EINK",
+      "platformioTargets": [
+        "seeed_wio_tracker_L1_eink"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 101,
+      "hwModelSlug": "MUZI_R1_NEO",
+      "platformioTargets": [
+        "r1-neo"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 105,
+      "hwModelSlug": "WISMESH_TAG",
+      "platformioTargets": [
+        "rak_wismeshtag"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 108,
+      "hwModelSlug": "HELTEC_MESH_SOLAR",
+      "platformioTargets": [
+        "heltec-mesh-solar"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 109,
+      "hwModelSlug": "T_ECHO_LITE",
+      "platformioTargets": [
+        "t-echo-lite"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 115,
+      "hwModelSlug": "THINKNODE_M3",
+      "platformioTargets": [
+        "thinknode_m3"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 117,
+      "hwModelSlug": "RAK3401",
+      "platformioTargets": [
+        "rak3401-1watt"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 119,
+      "hwModelSlug": "THINKNODE_M4",
+      "platformioTargets": [
+        "thinknode_m4"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 120,
+      "hwModelSlug": "THINKNODE_M6",
+      "platformioTargets": [
+        "thinknode_m6"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 127,
+      "hwModelSlug": "HELTEC_MESH_NODE_T096",
+      "platformioTargets": [
+        "heltec-mesh-node-t096"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 128,
+      "hwModelSlug": "MESH_TRACKER_X1",
+      "platformioTargets": [
+        "seeed_mesh_tracker_X1"
+      ],
+      "softDevice": "7.3.0"
+    },
+    {
+      "hwModel": 130,
+      "hwModelSlug": "THINKNODE_M8",
+      "platformioTargets": [
+        "thinknode_m8"
+      ]
+    },
+    {
+      "hwModel": 133,
+      "hwModelSlug": "HELTEC_MESH_NODE_T1",
+      "platformioTargets": [
+        "heltec-mesh-node-t1"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 136,
+      "hwModelSlug": "T_ECHO_CARD",
+      "platformioTargets": [
+        "t-echo-card"
+      ],
+      "softDevice": "6.1.1"
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { favicon } from "@tinyhttp/favicon";
 import { logger } from "@tinyhttp/logger";
 import { RegisterMqttClient } from "./lib/index.js";
 import {
+  BootloaderOtaQuirksRoutes,
   DeviceLinksRoutes,
   EventFirmwareIconRoutes,
   EventFirmwareRoutes,
@@ -84,6 +85,7 @@ app
 FirmwareRoutes();
 GithubRoutes();
 ResourceRoutes();
+BootloaderOtaQuirksRoutes();
 DeviceLinksRoutes();
 EventFirmwareRoutes();
 EventFirmwareIconRoutes();

--- a/src/lib/bootloaderOtaQuirks.ts
+++ b/src/lib/bootloaderOtaQuirks.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+
+// nRF52 bootloader/OTA quirk catalog. Source of truth was Meshtastic-Android's bundled
+// androidApp/src/main/assets/device_bootloader_ota_quirks.json (moved here 2026-08-20, per
+// thebentern) so other clients can read it without bundling their own stale copy. Android is
+// the only real consumer today; apple's OTAFIX bootloader-upgrade flow (PRs #2338/#2339) mirrors
+// its own board map by hand and could take `devices` as the "upgrade your bootloader first"
+// advisory, and web-flasher's drag-and-drop UF2 flow has no such nudge at all. The path resolves
+// the same in dev (src/lib) and prod (dist/lib), both two levels below the repo root.
+const DATA_PATH = new URL("../../data/bootloaderOtaQuirks.json", import.meta.url);
+
+/**
+ * Advisory only: devices that usually ship with a bootloader lacking OTA support and need a
+ * one-time upgrade (typically over USB) before BLE DFU works. Safe to fail open — a client that
+ * cannot reach this endpoint should still let the update attempt proceed.
+ */
+export interface BootloaderOtaQuirk {
+  hwModel: number;
+  hwModelSlug?: string;
+  requiresBootloaderUpgradeForOta: boolean;
+  infoUrl?: string;
+}
+
+/**
+ * The Nordic SoftDevice a given hwModel/target combination is linked against. Gates a
+ * destructive flash (wrong SoftDevice = a corrupted radio recoverable only via SWD/serial DFU),
+ * so unlike [BootloaderOtaQuirk] this must fail closed: an unresolved or absent entry is a
+ * deliberate refusal, not a gap to paper over with a best guess.
+ */
+export interface SoftDeviceVariantEntry {
+  hwModel: number;
+  hwModelSlug?: string;
+  platformioTargets: string[];
+  softDevice?: string;
+}
+
+export interface BootloaderOtaQuirksResponse {
+  devices: BootloaderOtaQuirk[];
+  softDeviceVariants: SoftDeviceVariantEntry[];
+}
+
+// Parse once per process — the file only changes via a committed edit + redeploy, same as
+// eventFirmware and deviceLinks.
+let cached: BootloaderOtaQuirksResponse | null = null;
+
+export const getBootloaderOtaQuirks = (): BootloaderOtaQuirksResponse => {
+  if (!cached) {
+    cached = JSON.parse(
+      readFileSync(DATA_PATH, "utf8"),
+    ) as BootloaderOtaQuirksResponse;
+  }
+  return cached;
+};

--- a/src/lib/bootloaderOtaQuirks.ts
+++ b/src/lib/bootloaderOtaQuirks.ts
@@ -7,7 +7,10 @@ import { readFileSync } from "node:fs";
 // its own board map by hand and could take `devices` as the "upgrade your bootloader first"
 // advisory, and web-flasher's drag-and-drop UF2 flow has no such nudge at all. The path resolves
 // the same in dev (src/lib) and prod (dist/lib), both two levels below the repo root.
-const DATA_PATH = new URL("../../data/bootloaderOtaQuirks.json", import.meta.url);
+const DATA_PATH = new URL(
+  "../../data/bootloaderOtaQuirks.json",
+  import.meta.url,
+);
 
 /**
  * Advisory only: devices that usually ship with a bootloader lacking OTA support and need a

--- a/src/routes/bootloaderOtaQuirks.ts
+++ b/src/routes/bootloaderOtaQuirks.ts
@@ -1,0 +1,12 @@
+import { app } from "../index.js";
+import { getBootloaderOtaQuirks } from "../lib/bootloaderOtaQuirks.js";
+
+export const BootloaderOtaQuirksRoutes = () =>
+  app.get("resource/bootloaderOtaQuirks", (_req, res) => {
+    try {
+      res.json(getBootloaderOtaQuirks());
+    } catch (err) {
+      console.error("bootloaderOtaQuirks", err);
+      res.sendStatus(502);
+    }
+  });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,4 @@
+export { BootloaderOtaQuirksRoutes } from "./bootloaderOtaQuirks.js";
 export { DeviceLinksRoutes } from "./deviceLinks.js";
 export { EventFirmwareRoutes } from "./eventFirmware.js";
 export { EventFirmwareIconRoutes } from "./eventFirmwareIcon.js";


### PR DESCRIPTION
Move Meshtastic-Android's bundled device_bootloader_ota_quirks.json here
verbatim (thebentern's proposal) so apple and web-flasher can read the same
nRF52 bootloader-upgrade advisory and SoftDevice-variant table Android
carries as an app asset, instead of each client bundling its own stale copy.

Mirrors eventFirmware.ts: the committed file is already in response shape,
so it's parsed once per process and served as-is.

Android now consumes this via a Room-backed cache seeded from its bundled
asset (meshtastic/Meshtastic-Android#6802) — an empty/unreachable network
response never wipes the seed, so the SoftDevice-gating table stays
fail-closed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>