### PR TITLE
Dragontastic: Fix URLs

### DIFF
--- a/data/eventFirmware.json
+++ b/data/eventFirmware.json
@@ -180,8 +180,9 @@
       "domain": "dragon.meshtastic.org",
       "links": [
         { "label": "Dragon Con Firmware Flasher", "url": "https://dragon.meshtastic.org" },
+        { "label": "EFF @ Dragon Con", "url": "https://www.eff.org/event/eff-dragoncon-1" },
         { "label": "MtnMe.sh Community", "url": "https://mtnme.sh" },
-        { "label": "Event Website", "url": "https://dragoncon.com" }
+        { "label": "Event Website", "url": "https://dragoncon.org" }
       ],
       "theme": {
         "name": "40th Anniversary",
@@ -196,7 +197,7 @@
         "id": "v2.8.0.a820487",
         "title": "Meshtastic Firmware 2.8.0.a820487",
         "zipUrl": null,
-        "releaseNotes": "## Welcome to Dragon Con 2026! 🐉\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Dragon Con 2026 firmware before joining the mesh. Use the [Dragon Con Firmware Flasher](https://dragon.meshtastic.org) to install the current release.\n\nThis Dragon Con firmware includes event defaults tuned for Atlanta, including the MEDIUM_FAST modem preset, frequency slot 45, event channels, and event routing limits.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Dragon Con mode.\n\n### Learn More\n\n- [Dragon Con Firmware Flasher](https://dragon.meshtastic.org)\n- [Quick Start Guide](https://docs.meshtastic.org/en/guides/quick_start)\n- [Meshtastic Discord](https://discord.gg/eXUBcCEJuH)"
+        "releaseNotes": "## Welcome to Dragon Con 2026! 🐉\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Dragon Con 2026 firmware before joining the mesh. Use the [Dragon Con Firmware Flasher](https://dragon.meshtastic.org) to install the current release.\n\nThis Dragon Con firmware includes event defaults tuned for Atlanta, including the MEDIUM_FAST modem preset, frequency slot 45, event channels, and event routing limits.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Dragon Con mode.\n\n### Learn More\n\n- [Dragon Con Firmware Flasher](https://dragon.meshtastic.org)\n- [Quick Start Guide](https://docs.meshtastic.org/en/guides/quick_start)\n- [EFF @ Dragon Con](https://www.eff.org/event/eff-dragoncon-1)\n- [Meshtastic Discord](https://discord.gg/meshtastic)"
       }
     }
   ]


### PR DESCRIPTION
Add "EFF @ Dragon Con" URL, fix Discord URL to point at Meshtastic properly (was pointing at Burning Mesh) and fix DragonCon URL (.org not .com) 🤖