### PR TITLE
fix: map SoftDevice variants for the new nrf52840 boards

### DIFF
--- a/data/bootloaderOtaQuirks.json
+++ b/data/bootloaderOtaQuirks.json
@@ -32,7 +32,9 @@
       "hwModel": 9,
       "hwModelSlug": "RAK4631",
       "platformioTargets": [
-        "rak4631"
+        "rak4631",
+        "rak_wismesh_pocket",
+        "rak_wismesh_repeater_mini"
       ],
       "softDevice": "6.1.1"
     },
@@ -217,7 +219,8 @@
       "hwModel": 117,
       "hwModelSlug": "RAK3401",
       "platformioTargets": [
-        "rak3401-1watt"
+        "rak3401-1watt",
+        "rak_wismesh_repeater_mini_hp"
       ],
       "softDevice": "6.1.1"
     },
@@ -275,6 +278,22 @@
         "t-echo-card"
       ],
       "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 139,
+      "hwModelSlug": "HELTEC_MESH_TOWER_V2",
+      "platformioTargets": [
+        "heltec-mesh-tower-v2"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 144,
+      "hwModelSlug": "SEEED_WIO_TRACKER_L1_PRO_1W",
+      "platformioTargets": [
+        "seeed_wio_tracker_L1_Pro_1W"
+      ],
+      "softDevice": "7.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Why

The Meshtastic-Android #6822 hardware-catalog refresh added nrf52840 boards with no SoftDevice mapping, so the destructive-flash gate would refuse OTA updates for them. Android PR meshtastic/Meshtastic-Android#6843 fixed the app's bundled seed (androidApp/src/main/assets/device_bootloader_ota_quirks.json), but that seed is refreshed on a schedule from this repo's resource/bootloaderOtaQuirks data. Without the same rows here, the next scheduled refresh reverts the app fix.

## What

Four changes to data/bootloaderOtaQuirks.json, all under softDeviceVariants:

- hwModel 9 (RAK4631): add platformioTargets rak_wismesh_pocket and rak_wismesh_repeater_mini (softDevice stays 6.1.1)
- hwModel 117 (RAK3401): add platformioTarget rak_wismesh_repeater_mini_hp (softDevice stays 6.1.1)
- New row hwModel 139 HELTEC_MESH_TOWER_V2, target heltec-mesh-tower-v2, softDevice 6.1.1
- New row hwModel 144 SEEED_WIO_TRACKER_L1_PRO_1W, target seeed_wio_tracker_L1_Pro_1W, softDevice 7.3.0

## Derivation

From meshtastic/firmware ldscripts: heltec_mesh_tower_v2 links nrf52840_s140_v6.ld (SoftDevice 6.1.1); seeed_wio_tracker_L1_Pro_1W links nrf52840_s140_v7.ld (7.3.0); rak_wismesh_pocket, rak_wismesh_repeater_mini, and rak_wismesh_repeater_mini_hp all build on wiscore_rak4631 with v6 (6.1.1).

## Testing Performed

- JSON parses; 34 variant rows, hwModel-sorted, no duplicate hwModel or platformioTarget values
- Verified the added rows match the schema in src/lib/bootloaderOtaQuirks.ts (SoftDeviceVariantEntry)
- No repo test script covers this data file (package.json only has validate:maintenance-uf2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mU7P5KvLFZFNoHL4ExrBN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RAK WiMesh Pocket and Repeater Mini devices.
  * Added support for the WiMesh Repeater Mini HP.
  * Added soft-device variants for Heltec Mesh Tower V2 and Seeed Wio Tracker L1 Pro 1W.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->