### PR TITLE
fix: return no origin instead of throwing for disallowed CORS origins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,16 @@ app
         if (whitelist.indexOf(req.headers.origin) !== -1) {
           return req.headers.origin;
         }
-        throw new Error("Origin not allowed by CORS");
+
+        // Not allowed: return no origin rather than throwing. @tinyhttp/cors
+        // passes this return value straight to res.setHeader and does not catch,
+        // so throwing here escaped the middleware and turned every request from a
+        // non-whitelisted origin into a 500 -- including the OPTIONS preflight.
+        // An empty value is the same denial the no-origin branch above already
+        // returns: the browser sees no matching Access-Control-Allow-Origin and
+        // blocks the read, which is where that decision belongs. Credentials are
+        // enabled, so a wildcard is not an option.
+        return "";
       },
     }),
   )


### PR DESCRIPTION
## Why

A request from an origin outside the whitelist gets **HTTP 500**, not a CORS denial.

`@tinyhttp/cors` passes the `origin()` return value straight into `res.setHeader` and never wraps the call, so the `throw new Error("Origin not allowed by CORS")` at `src/index.ts:56` escapes the middleware and becomes a 500 for the whole request, preflight included.

That is wrong in three ways:

1. **It reports a client-side policy decision as a server fault.** A disallowed origin is a normal, expected outcome. It should not surface as a 5xx, page as an outage, or land in logs as one.
2. **It hides the real cause.** The browser shows a generic 500 rather than a CORS error, and `curl` against the same endpoint looks perfectly healthy because a plain request sends no `Origin` at all. This cost me a while to pin down.
3. **Enforcement does not belong on the server here.** Omitting the header and letting the browser block the read is exactly what the no-origin branch a few lines above already does.

Returning `""` for a disallowed origin makes the two paths consistent. `credentials: true` is set, so a wildcard is not an option and none is proposed.

On why `""` and not something more explicit, since `origin()` feeds `res.setHeader` directly (measured, same harness as below):

| `origin()` returns | result |
| --- | --- |
| `""` | 200, `access-control-allow-origin: ""` |
| `false` | 200, `access-control-allow-origin: false` |
| `null` | 200, `access-control-allow-origin: null` |
| `undefined` | **500**, `ERR_HTTP_INVALID_HEADER_VALUE` |

`false` and `null` do deny correctly, they just put a junk token on the wire that reads like a bug to the next person. `undefined` swaps one 500 for another. `""` is the value this service already emits for no-Origin requests, so it is the one with production evidence behind it.

> Correction: the commit message on this branch says `false` "is not a valid header value". That is wrong, as the table shows. I could not amend it without a force-push; this section is the accurate version.

**Nothing about which origins are allowed changes in this PR.**

## Testing Performed

Verified against `@tinyhttp/cors` 2.0.0 (the pinned version) with a local harness running the current and proposed `origin()` side by side:

| case | method | current | proposed |
| --- | --- | --- | --- |
| no `Origin` | GET | 200, `acao: ""` | 200, `acao: ""` |
| allowed origin | GET | 200, `acao: https://meshtastic.org` | 200, `acao: https://meshtastic.org` |
| disallowed origin | GET | **500** | 200, `acao: ""` |
| disallowed origin | OPTIONS | **500** | 204, `acao: ""` |

The 500s match production today:

```
$ curl -o /dev/null -w '%{http_code}' -H 'Origin: https://client.meshtastic.org' \
    https://api.meshtastic.org/resource/deviceHardware
500                       # body: Origin not allowed by CORS

$ curl -o /dev/null -w '%{http_code}' -H 'Origin: https://meshtastic.org' ...
200                       # access-control-allow-origin: https://meshtastic.org

$ curl -o /dev/null -w '%{http_code}' -H 'Origin: http://localhost:3000' ...
200                       # access-control-allow-origin: http://localhost:3000
```

A plain request with no `Origin` already receives an empty `access-control-allow-origin` in production, so the proposed value is behaviour this service is known to serve correctly.

`biome ci` over `src/` and `scripts/` is unchanged: 0 errors, and the same 2 pre-existing warnings in `src/lib/mqtt.ts` and `src/services/gateway.ts`, neither touched here. I could not run `pnpm install` locally (4 `@buf/*` lockfile entries have no `integrity` field, which pnpm 11 rejects; CI's pnpm 9 does not enforce this), so `pnpm build` is unverified locally. The change is one return statement inside an existing `string`-returning function, so I would expect `tsc` to be indifferent, but worth a CI confirmation.

## Two related findings, not fixed here

Both turned up while tracking down the above. Neither is actionable in this repo, flagging them rather than guessing at a fix.

1. **`client.meshtastic.org` is not on its own API's allowlist.** It is live and serving, but gets the 500 above. `map.meshtastic.org` and `flasher.meshtastic.org` are on the list. Adding an origin is your call, not a bug fix, so I deliberately left the whitelist untouched. Happy to add it in a follow-up if you want it.

2. **apiv2 serves `iconUrl` values pointing at `api.meshtastic.org`.** `src/routes/eventFirmware.ts` re-origins hosted icon URLs off `X-Forwarded-Host`, which is exactly right, but apiv2 responds with `server: cloudflare` and no `x-powered-by: tinyhttp` and ignores cache-busting query strings, so it is serving R2 objects without running this route. The result is that on apiv2 the event icon URLs still point at v1, where a browser request for them hits the 500 this PR fixes. That lives in the apiv2 Worker/R2 sync rather than here, so there is nothing to change in this repo, but you will want it on the list.

## Context

Found while pointing the Meshtastic Android/desktop/web app at `apiv2.meshtastic.org`. The wasmJs web target cannot use v1 at all because of this 500; apiv2 serves `access-control-allow-origin: *` and a 204 preflight. Payload parity between the two hosts checked out across all six endpoints the app consumes plus the maintenance UF2 binaries (byte-identical, digests match).

/cc @thebentern
