### PR TITLE
Add Seeed Wio Tracker L2 to the device hardware registry

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1388,7 +1388,9 @@ export const deviceHardwareList: DeviceHardware[] = [
     architecture: "esp32-s3",
     activelySupported: false,
     supportLevel: 1,
-    displayName: "Seeed Wio Tracker L2",
+    displayName: "Seeed Wio Tracker L2 Pro",
     tags: ["Seeed"],
+    requiresDfu: true,
+    partitionScheme: "16MB",
   },
 ];

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1381,4 +1381,14 @@ export const deviceHardwareList: DeviceHardware[] = [
     images: ["rak3401.svg"],
     requiresDfu: true,
   },
+  {
+    hwModel: 137,
+    hwModelSlug: "SEEED_WIO_TRACKER_L2",
+    platformioTarget: "seeed-wio-tracker-l2",
+    architecture: "esp32-s3",
+    activelySupported: false,
+    supportLevel: 1,
+    displayName: "Seeed Wio Tracker L2",
+    tags: ["Seeed"],
+  },
 ];


### PR DESCRIPTION
Adds the **Seeed Studio Wio Tracker L2** to `deviceHardwareList`, keyed by [`SEEED_WIO_TRACKER_L2 = 137`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L919).

```ts
  {
    hwModel: 137,
    hwModelSlug: "SEEED_WIO_TRACKER_L2",
    platformioTarget: "seeed-wio-tracker-l2",
    architecture: "esp32-s3",
    activelySupported: false,
    supportLevel: 1,
    displayName: "Seeed Wio Tracker L2 Pro",
    tags: ["Seeed"],
  },
```

Review checklist:
- [x] `platformioTarget` — **derived from the slug**; confirm against the firmware variant
- [ ] flip `activelySupported` / `supportLevel` when the web flasher should list it
- [ ] add `images` once the device SVG lands
- [x] `requiresDfu` / `partitionScheme` if the platform needs them

_Entry generated from the live mesh.proto and registry at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Devices**
  * Added the Seeed Wio Tracker L2 Pro to the device catalog.
  * Listed the device with inactive support and DFU flashing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->