### PR TITLE
Mark T-Lora C6 as actively supported

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1166,7 +1166,7 @@ export const deviceHardwareList: DeviceHardware[] = [
     hwModelSlug: "TLORA_C6",
     platformioTarget: "tlora-c6",
     architecture: "esp32-c6",
-    activelySupported: false,
+    activelySupported: true,
     supportLevel: 1,
     displayName: "LilyGo T-Lora C6",
     tags: ["LilyGo"],


### PR DESCRIPTION
Flips `activelySupported` for the **LilyGo T-Lora C6** (`TLORA_C6 = 83`) so the web flasher lists it.

Review checklist:
- [x] `public/img/devices/tlora-c6.svg` exists in meshtastic/web-flasher — merge the device-image PR first
- [x] `supportLevel` is right for this device

_Generated from the live registry at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added active support for the TLORA_C6 device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->