### PR TITLE
Change activelySupported to true for MINI_EPAPER_S3

### DIFF
--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1118,7 +1118,7 @@ export const deviceHardwareList: DeviceHardware[] = [
     hwModelSlug: "MINI_EPAPER_S3",
     platformioTarget: "mini-epaper-s3",
     architecture: "esp32-s3",
-    activelySupported: false,
+    activelySupported: true,
     supportLevel: 1,
     displayName: "LilyGo Mini E-paper S3",
     tags: ["LilyGo"],


### PR DESCRIPTION
Mini Epaper S3 support is complete and ready to be active. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MINI EPAPER S3 is now actively supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->